### PR TITLE
Spaces in params

### DIFF
--- a/nancy
+++ b/nancy
@@ -52,8 +52,6 @@ do
 done
 
 echo "CMD: $cmd"
-echo "ORIG: $@"
 
-set -xeio pipefail
 eval $cmd
 

--- a/nancy
+++ b/nancy
@@ -43,11 +43,17 @@ esac
 
 while [ -n "$1" ]
 do
+  if [ ${1%"${1#??}"} = '--' ]; then
     cmd="$cmd $1"
-    shift
+  else
+    cmd="$cmd \"$1\""
+  fi
+  shift
 done
 
 echo "CMD: $cmd"
+echo "ORIG: $@"
 
-${cmd}
+set -xeio pipefail
+eval $cmd
 


### PR DESCRIPTION
This didn't work before:

```bash
nancy run --param "some thing"
```
(while `./nancy_run.sh --param "some thing"` worked fine).

This PR resolves this issue.

The solution used might happen to be fragile, more tests are needed here.

One possible problem is that if single quotes are used for params (`nancy command --param 'some$thing'`), we internally convert them to double quotes (`./nancy_command.sh --param "some$thing"`), and this might cause unexpected behavior, like demonstrated here:
```
[nikolay@dev nancy] 2018-07-08 23:17:47 $ echo 'some$thing'
some$thing
[nikolay@dev nancy] 2018-07-08 23:17:54 $ echo "some$thing"
some
[nikolay@dev nancy] 2018-07-08 23:17:58 $
```