### PR TITLE
fix cleanup steps

### DIFF
--- a/nancy_run.sh
+++ b/nancy_run.sh
@@ -539,6 +539,7 @@ function destroyDockerMachine() {
 
 function cleanupAndExit {
   echo "Remove temp files..." # if exists
+  docker $dockerConfig exec -i ${containerHash} sh -c "sudo rm -rf $MACHINE_HOME"
   rm -f "$TMP_PATH/after_db_init_code_tmp.sql"
   rm -f "$TMP_PATH/workload_custom_sql_tmp.sql"
   rm -f "$TMP_PATH/target_ddl_do_tmp.sql"
@@ -546,7 +547,6 @@ function cleanupAndExit {
   rm -f "$TMP_PATH/target_config_tmp.conf"
   rm -f "$TMP_PATH/pg_config_tmp.conf"
   if [ "$RUN_ON" = "localhost" ]; then
-    rm -rf "$TMP_PATH/nancy_${containerHash}"
     echo "Remove docker container"
     docker container rm -f $containerHash
   elif [ "$RUN_ON" = "aws" ]; then
@@ -746,6 +746,7 @@ docker_exec bash -c "/root/pgbadger/pgbadger \
   -j $(cat /proc/cpuinfo | grep processor | wc -l) \
   --prefix '%t [%p]: [%l-1] db=%d,user=%u (%a,%h)' /var/log/postgresql/* -f stderr \
   -o $MACHINE_HOME/$ARTIFACTS_FILENAME.json"
+  #2> >(grep -v "install the Text::CSV_XS" >&2)
 
 echo "Save JSON log..."
 if [[ $ARTIFACTS_DESTINATION =~ "s3://" ]]; then


### PR DESCRIPTION
In $TMP_PATH directory (mapped to `/machine_home` in the container), the container creates a subdirectory `nancy_*****`. In the end, we need to delete it (`cleanupAndExit` function).

The problem is that it cannot be removed without using `sudo` so we get an error:
```
rm: cannot remove ‘/tmp/nancy_9326749f1ee7df0d176646395fdc9786dbf67883d55217f9e28f301a97da8954’: Operation not permitted
```
This PR resolves this: instead of direct `rm -rf` we use `docker exec ...` call.